### PR TITLE
Create c_gls_WB_GLOBE_S2.txt

### DIFF
--- a/ColourMaps/c_gls_WB_GLOBE_S2.txt
+++ b/ColourMaps/c_gls_WB_GLOBE_S2.txt
@@ -1,0 +1,3 @@
+# Fichier d'export QGIS de palette de couleur
+INTERPOLATION:EXACT
+70,31,113,220,254,Inland water


### PR DESCRIPTION
This is the color map for the CGLOPS WB product in txt format. This is the style corresponding to the WB raster variable in the netcdf.